### PR TITLE
Proxmox autoscaler implementation

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum"
 	oci "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/instancepools"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ovhcloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/proxmox"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/rancher"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/tencentcloud"

--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -86,6 +86,7 @@ var AvailableCloudProviders = []string{
 	cloudprovider.ScalewayProviderName,
 	cloudprovider.RancherProviderName,
 	cloudprovider.VolcengineProviderName,
+	cloudprovider.ProxmoxProviderName,
 }
 
 // DefaultCloudProvider is GCE.

--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -153,6 +153,8 @@ func buildCloudProvider(opts config.AutoscalingOptions,
 		return rancher.BuildRancher(opts, do, rl)
 	case cloudprovider.VolcengineProviderName:
 		return volcengine.BuildVolcengine(opts, do, rl)
+	case cloudprovider.ProxmoxProviderName:
+		return proxmox.BuildProxmoxEngine(opts, do, rl)
 	}
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/builder/builder_proxmox.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_proxmox.go
@@ -1,0 +1,43 @@
+//go:build proxmox
+// +build proxmox
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/client-go/informers"
+)
+
+// AvailableCloudProviders supported by the Proxmox cloud provider builder.
+var AvailableCloudProviders = []string{
+	cloudprovider.ProxmoxProviderName,
+}
+
+// DefaultCloudProvider is Proxmox.
+const DefaultCloudProvider = cloudprovider.ProxmoxProviderName
+
+func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+	switch opts.CloudProviderName {
+	case cloudprovider.ProxmoxProviderName:
+		return proxmox.BuildProxmoxEngine(opts, do, rl)
+	}
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -90,6 +90,8 @@ const (
 	CivoProviderName = "civo"
 	// RancherProviderName gets the provider name of rancher
 	RancherProviderName = "rancher"
+	// ProxmoxProviderName gets the provider name of proxmox
+	ProxmoxProviderName = "proxmox"
 )
 
 // GpuConfig contains the label, type and the resource name for a GPU.

--- a/cluster-autoscaler/cloudprovider/proxmox/README.md
+++ b/cluster-autoscaler/cloudprovider/proxmox/README.md
@@ -1,3 +1,14 @@
+# Proxmox Cloud Provider for Cluster Autoscaling
+
+## How to create a template LXC container
+[This gist](https://gist.github.com/triangletodd/02f595cd4c0dc9aac5f7763ca2264185) has good information on creating such a template.
+Along with it, ensure the following are satisfied:
+
+* Set a container ID that has free IDs following it. Each new worker will have a sequential ID following this container ID
+* `curl` is installed in the container (necessary for `k3s` installation)
+* The `automation_key` supplied below is added to the `authorized_keys` (either during container creation or manually later)
+* If using Longhorn, install `open-iscsi` and `nfs-common` packages as well
+
 
 ## Autoscaler Config
 
@@ -32,11 +43,11 @@
 
 The API token needs the following permissions with propagate enabled:
 
-|      **Path**      |     **Role**     |            **Reason**           |
-|:------------------:|:----------------:|:-------------------------------:|
-| /                  | PVEAuditor       | Reading node and template info  |
-| /                  | PVETemplateUser  | Using the template              |
-| /pool/{poolName}   | PVEPoolUser      | List all pools                  |
-| /pool/{poolName}   | PVEVMAdmin       | Create/Delete containers        |
-| /storage/local-lvm | PVEDatastoreUser | Allocate storage for containers |
-| /sdn/zones         | PVESDNUser       | Attach to network               |
+|       **Path**       |      **Role**      |            **Reason**           |
+|:---------------------|:-------------------|:--------------------------------|
+| `/`                  | `PVEAuditor`       | Reading node and template info  |
+| `/`                  | `PVETemplateUser`  | Using the template              |
+| `/pool/{targetPool}` | `PVEPoolUser`      | List the relevant pools         |
+| `/pool/{targetPool}` | `PVEVMAdmin`       | Create/Delete containers        |
+| `/storage/local-lvm` | `PVEDatastoreUser` | Allocate storage for containers |
+| `/sdn/zones`         | `PVESDNUser`       | Attach to network               |

--- a/cluster-autoscaler/cloudprovider/proxmox/README.md
+++ b/cluster-autoscaler/cloudprovider/proxmox/README.md
@@ -1,0 +1,37 @@
+
+## Autoscaler Config
+
+```json
+{
+    "insecureSkipVerify": true,
+    "apiEndpoint": "https://proxmox.cluster.local:8006/api2/json",
+    "apiUser": "root@pam!autoscaling",
+    "apiToken": "sample-api-token",
+    "nodeConfigs": [
+        {
+            "refCtrId": 600,
+            "targetPool": "Autoscaling",
+            "workerNamePrefix": "k8s-worker-autoscaled"
+        }
+    ],
+    "timeoutSeconds": 30,
+    "k3sConfig": {
+        "sshKeyFile": "automation_key",
+        "serverUser": "master",
+        "serverHost": "k8s-master.cluster.local",
+        "user": "root"
+    }
+}
+```
+
+## Permissions
+
+The API token needs the following permissions with propagate enabled:
+
+|      **Path**      |     **Role**     |            **Reason**           |
+|:------------------:|:----------------:|:-------------------------------:|
+| /                  | PVEAuditor       | Reading node and template info  |
+| /                  | PVETemplateUser  | Using the template              |
+| /pool/{poolName}   | PVEVMAdmin       | Create/Delete containers        |
+| /storage/local-lvm | PVEDatastoreUser | Allocate storage for containers |
+| /sdn/zones         | PVESDNUser       | Attach to network               |

--- a/cluster-autoscaler/cloudprovider/proxmox/README.md
+++ b/cluster-autoscaler/cloudprovider/proxmox/README.md
@@ -11,7 +11,9 @@
         {
             "refCtrId": 600,
             "targetPool": "Autoscaling",
-            "workerNamePrefix": "k8s-worker-autoscaled"
+            "workerNamePrefix": "k8s-worker-autoscaled",
+            "minSize": 0,
+            "maxSize": 10,
         }
     ],
     "timeoutSeconds": 30,

--- a/cluster-autoscaler/cloudprovider/proxmox/README.md
+++ b/cluster-autoscaler/cloudprovider/proxmox/README.md
@@ -3,20 +3,22 @@
 
 ```json
 {
-    "insecureSkipVerify": true,
-    "apiEndpoint": "https://proxmox.cluster.local:8006/api2/json",
-    "apiUser": "root@pam!autoscaling",
-    "apiToken": "sample-api-token",
+    "proxmoxConfig": {
+        "apiEndpoint": "https://proxmox.cluster.local:8006/api2/json",
+        "apiUser": "root@pam!autoscaling",
+        "apiToken": "sample-api-token",
+        "insecureSkipVerify": true,
+        "timeoutSeconds": 30
+    },
     "nodeConfigs": [
         {
             "refCtrId": 600,
             "targetPool": "Autoscaling",
             "workerNamePrefix": "k8s-worker-autoscaled",
             "minSize": 0,
-            "maxSize": 10,
+            "maxSize": 10
         }
     ],
-    "timeoutSeconds": 30,
     "k3sConfig": {
         "sshKeyFile": "automation_key",
         "serverUser": "master",

--- a/cluster-autoscaler/cloudprovider/proxmox/README.md
+++ b/cluster-autoscaler/cloudprovider/proxmox/README.md
@@ -34,6 +34,7 @@ The API token needs the following permissions with propagate enabled:
 |:------------------:|:----------------:|:-------------------------------:|
 | /                  | PVEAuditor       | Reading node and template info  |
 | /                  | PVETemplateUser  | Using the template              |
+| /pool/{poolName}   | PVEPoolUser      | List all pools                  |
 | /pool/{poolName}   | PVEVMAdmin       | Create/Delete containers        |
 | /storage/local-lvm | PVEDatastoreUser | Allocate storage for containers |
 | /sdn/zones         | PVESDNUser       | Attach to network               |

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+)
+
+func BuildProxmoxEngine(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider_impl.go
@@ -30,8 +30,16 @@ func (p *ProxmoxCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
 func (p *ProxmoxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	refId, ok := node.Labels[RefIdLabel]
+
+	// Not managed by autoscaler
+	if !ok {
+		return nil, nil
+	}
+
+	// Find node group
 	for _, ng := range p.manager.NodeGroupManagers {
-		if node.Labels[RefIdLabel] == fmt.Sprint(ng.NodeConfig.RefCtrId) {
+		if refId == fmt.Sprint(ng.NodeConfig.RefCtrId) {
 			return ng, nil
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider_impl.go
@@ -1,6 +1,9 @@
 package proxmox
 
 import (
+	"context"
+	"fmt"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -15,48 +18,89 @@ func (p *ProxmoxCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (p *ProxmoxCloudProvider) NodeGroups() []cloudprovider.NodeGroup {}
+func (p *ProxmoxCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+	ngs := make([]cloudprovider.NodeGroup, 0, len(p.manager.NodeGroupManagers))
+	for _, ng := range p.manager.NodeGroupManagers {
+		ngs = append(ngs, ng)
+	}
+	return ngs
+}
 
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (p *ProxmoxCloudProvider) NodeGroupForNode(*apiv1.Node) (cloudprovider.NodeGroup, error) {}
+func (p *ProxmoxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	for _, ng := range p.manager.NodeGroupManagers {
+		if node.Labels[RefIdLabel] == fmt.Sprint(ng.NodeConfig.RefCtrId) {
+			return ng, nil
+		}
+	}
+	return nil, fmt.Errorf("no matching nodegroup found for node %s", node.Name)
+}
 
 // HasInstance returns whether the node has corresponding instance in cloud provider,
 // true if the node has an instance, false if it no longer exists
-func (p *ProxmoxCloudProvider) HasInstance(*apiv1.Node) (bool, error) {}
+func (p *ProxmoxCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+	_, err := p.NodeGroupForNode(node)
+	if err != nil {
+		return false, err
+	} else {
+		return true, nil
+	}
+}
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (p *ProxmoxCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {}
+func (p *ProxmoxCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+	return nil, cloudprovider.ErrNotImplemented
+}
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (p *ProxmoxCloudProvider) GetAvailableMachineTypes() ([]string, error) {}
+func (p *ProxmoxCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+	return []string{}, cloudprovider.ErrNotImplemented
+}
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
 func (p *ProxmoxCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (p *ProxmoxCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {}
+func (p *ProxmoxCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	return p.resourceLimiter, nil
+}
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (p *ProxmoxCloudProvider) GPULabel() string {}
+func (p *ProxmoxCloudProvider) GPULabel() string {
+	return GPULabel
+}
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (p *ProxmoxCloudProvider) GetAvailableGPUTypes() map[string]struct{} {}
+func (p *ProxmoxCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return nil
+}
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (p *ProxmoxCloudProvider) GetNodeGpuConfig(*apiv1.Node) *cloudprovider.GpuConfig {}
+func (p *ProxmoxCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+	return nil
+}
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (p *ProxmoxCloudProvider) Cleanup() error {}
+func (p *ProxmoxCloudProvider) Cleanup() error {
+	return nil
+}
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (p *ProxmoxCloudProvider) Refresh() error {}
+func (p *ProxmoxCloudProvider) Refresh() error {
+	ctx := context.Background()
+	for _, ngm := range p.manager.NodeGroupManagers {
+		ngm.FillCurrentSize(ctx)
+	}
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_cloud_provider_impl.go
@@ -1,0 +1,62 @@
+package proxmox
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+// cloudProvider.CloudProvider interface implementation on ProxmoxCloudProvider
+
+// Name returns name of the cloud provider.
+func (p *ProxmoxCloudProvider) Name() string {
+	return cloudprovider.ProxmoxProviderName
+}
+
+// NodeGroups returns all node groups configured for this cloud provider.
+func (p *ProxmoxCloudProvider) NodeGroups() []cloudprovider.NodeGroup {}
+
+// NodeGroupForNode returns the node group for the given node, nil if the node
+// should not be processed by cluster autoscaler, or non-nil error if such
+// occurred. Must be implemented.
+func (p *ProxmoxCloudProvider) NodeGroupForNode(*apiv1.Node) (cloudprovider.NodeGroup, error) {}
+
+// HasInstance returns whether the node has corresponding instance in cloud provider,
+// true if the node has an instance, false if it no longer exists
+func (p *ProxmoxCloudProvider) HasInstance(*apiv1.Node) (bool, error) {}
+
+// Pricing returns pricing model for this cloud provider or error if not available.
+// Implementation optional.
+func (p *ProxmoxCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {}
+
+// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
+// Implementation optional.
+func (p *ProxmoxCloudProvider) GetAvailableMachineTypes() ([]string, error) {}
+
+// NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
+// created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
+// Implementation optional.
+func (p *ProxmoxCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+}
+
+// GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
+func (p *ProxmoxCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (p *ProxmoxCloudProvider) GPULabel() string {}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports.
+func (p *ProxmoxCloudProvider) GetAvailableGPUTypes() map[string]struct{} {}
+
+// GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
+// any GPUs, it returns nil.
+func (p *ProxmoxCloudProvider) GetNodeGpuConfig(*apiv1.Node) *cloudprovider.GpuConfig {}
+
+// Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
+func (p *ProxmoxCloudProvider) Cleanup() error {}
+
+// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
+// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
+func (p *ProxmoxCloudProvider) Refresh() error {}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -16,14 +16,16 @@ import (
 	"github.com/luthermonson/go-proxmox"
 	pm "github.com/luthermonson/go-proxmox"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
 type NodeConfig struct {
-	RefCtrId         int
-	TargetPool       string
-	WorkerNamePrefix string
-	MinSize          int
-	MaxSize          int
+	RefCtrId           int
+	TargetPool         string
+	WorkerNamePrefix   string
+	MinSize            int
+	MaxSize            int
+	AutoScalingOptions config.NodeGroupAutoscalingOptions
 }
 
 type K3sConfig struct {
@@ -50,11 +52,10 @@ type NodeGroupManager struct {
 	K3sConfig      *K3sConfig
 	TimeoutSeconds int
 
-	node         *pm.Node
-	refCtr       *pm.Container
-	currentSize  int
-	targetSize   int
-	targetPoolId int
+	node        *pm.Node
+	refCtr      *pm.Container
+	currentSize int
+	targetSize  int
 }
 
 type ProxmoxManager struct {

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -60,7 +60,7 @@ type NodeGroupManager struct {
 
 type ProxmoxManager struct {
 	Client            *pm.Client
-	NodeGroupManagers []NodeGroupManager
+	NodeGroupManagers []*NodeGroupManager
 }
 
 func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager, err error) {
@@ -87,10 +87,10 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 		pm.WithAPIToken(config.ApiUser, config.ApiToken),
 	)
 
-	nodeGroupManagers := make([]NodeGroupManager, len(config.NodeConfigs))
+	nodeGroupManagers := make([]*NodeGroupManager, 0, len(config.NodeConfigs))
 
 	for _, nc := range config.NodeConfigs {
-		nodeGroupManagers = append(nodeGroupManagers, NodeGroupManager{
+		nodeGroupManagers = append(nodeGroupManagers, &NodeGroupManager{
 			Client:         client,
 			NodeConfig:     &nc,
 			K3sConfig:      &config.K3sConfig,

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -1,30 +1,50 @@
 package proxmox
 
 import (
+	"context"
+	"crypto/tls"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"log"
+	"net/http"
+	"net/netip"
+	"time"
 
+	k3sup "github.com/alexellis/k3sup/cmd"
 	"github.com/luthermonson/go-proxmox"
+	pm "github.com/luthermonson/go-proxmox"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
 // Configuration of the Proxmox Cloud Provider
 type Config struct {
 	InsecureSkipVerify   bool
+	ApiEndpoint          string
 	ApiUser              string
 	ApiToken             string
 	TargetPool           string
 	ReferenceContainerId int
+	TimeoutSeconds       int
+	SshKeyFile           string // SSH key file to use for login
+	ServerUser           string // Master node SSH login user
+	ServerHost           string // Master node IP or Hostname
+	User                 string // Worker node SSH login user
 }
 
 type ProxmoxManager struct {
-	Client         *proxmox.Client
+	Client         *pm.Client
 	TargetPool     string
 	RefCtrId       int
 	TimeoutSeconds int
+	SshKeyFile     string
+	ServerUser     string
+	ServerHost     string
+	User           string
 
-	node   *proxmox.Node
-	refCtr *proxmox.Container
+	node   *pm.Node
+	refCtr *pm.Container
 }
 
 func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager, err error) {
@@ -38,15 +58,191 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 		return
 	}
 
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: config.InsecureSkipVerify,
+			},
+		},
+	}
+
+	client := pm.NewClient(config.ApiEndpoint,
+		pm.WithHTTPClient(&httpClient),
+		pm.WithAPIToken(config.ApiUser, config.ApiToken),
+	)
+
 	return &ProxmoxManager{
-		Client:         nil,
+		Client:         client,
 		TargetPool:     config.TargetPool,
 		RefCtrId:       config.ReferenceContainerId,
-		TimeoutSeconds: con,
+		TimeoutSeconds: config.TimeoutSeconds,
+		SshKeyFile:     config.SshKeyFile,
+		ServerUser:     config.ServerUser,
+		ServerHost:     config.ServerHost,
+		User:           config.User,
+	}, nil
+}
+
+// Implement proxmox interations on ProxmoxManager
+
+func (p *ProxmoxManager) getInitialDetails(ctx context.Context) (err error) {
+	if p.node == nil {
+		// Get first node name
+		log.Println("Getting first node")
+		var nodeStatuses proxmox.NodeStatuses
+		nodeStatuses, err = p.Client.Nodes(ctx)
+		if err != nil {
+			return
+		}
+
+		// Get the node object
+		log.Printf("Getting node object for %s\n", nodeStatuses[0].Node)
+		p.node, err = p.Client.Node(ctx, nodeStatuses[0].Node)
+		if err != nil {
+			return
+		}
+	}
+
+	// Get reference container object
+	if p.refCtr == nil {
+		log.Printf("Geting reference container object for id %d\n", p.RefCtrId)
+		p.refCtr, err = p.node.Container(ctx, p.RefCtrId)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (p *ProxmoxManager) CloneToNewCt(ctx context.Context, newCtrOffset int) (ip netip.Addr, err error) {
+	if err = p.getInitialDetails(ctx); err != nil {
+		return
+	}
+
+	// Clone reference container. Return value is 0 when providing NewID
+	newId := p.RefCtrId + newCtrOffset
+	log.Printf("Cloning reference container %s to new container %d\n", p.refCtr.Name, newId)
+	_, task, err := p.refCtr.Clone(ctx, &proxmox.ContainerCloneOptions{
+		NewID:    newId,
+		Hostname: fmt.Sprintf("%s-%d", p.refCtr.Name, newCtrOffset),
+		Pool:     p.TargetPool,
+	})
+	if err != nil {
+		return
+	}
+
+	// Wait for task to complete
+	log.Println("Waiting for clone to complete")
+	if err = task.WaitFor(ctx, 4*p.TimeoutSeconds); err != nil {
+		return
+	}
+
+	// Get new container object
+	log.Printf("Getting the new container object for %d\n", newId)
+	newCtr, err := p.node.Container(ctx, newId)
+	if err != nil {
+		return
+	}
+
+	// Start the new container
+	log.Printf("Starting the new container %s\n", newCtr.Name)
+	task, err = newCtr.Start(ctx)
+	if err != nil {
+		return
+	}
+
+	// Wait for start up
+	log.Printf("Waiting for %s to start up", newCtr.Name)
+	if err = task.WaitFor(ctx, p.TimeoutSeconds); err != nil {
+		return
+	}
+
+	// Wait for IP to be assigned
+	log.Printf("Waiting for IP address to be assigned for %s ", newCtr.Name)
+	timeout := time.After(time.Duration(p.TimeoutSeconds) * time.Second)
+	for {
+		fmt.Print(".")
+		select {
+		case <-timeout:
+			return netip.Addr{}, errors.New("timed out waiting for IP")
+		default:
+			// Get list of ifaces
+			ifaces, err := newCtr.Interfaces(ctx)
+			if err != nil {
+				return netip.Addr{}, err
+			}
+
+			// Check the 2nd iface (1st is loopback)
+			if len(ifaces) >= 2 && len(ifaces[1].Inet) > 0 {
+				// Convert string to IP and return
+				prefix, err := netip.ParsePrefix(ifaces[1].Inet)
+				if err != nil {
+					return netip.Addr{}, err
+				}
+				fmt.Println()
+				log.Printf("Container %s created with IP %v\n", newCtr.Name, prefix)
+				return prefix.Addr(), nil
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
 	}
 }
 
-// TODO: Implement proxmox interations on proxmoxManager
+func (p *ProxmoxManager) DeleteCt(ctx context.Context, ctrOffset int) (err error) {
+	if err = p.getInitialDetails(ctx); err != nil {
+		return
+	}
+
+	// Get container object
+	log.Printf("Getting the container object for %d\n", p.RefCtrId+ctrOffset)
+	ctr, err := p.node.Container(ctx, p.RefCtrId+ctrOffset)
+	if err != nil {
+		return
+	}
+
+	// Shutdown container
+	task, err := ctr.Shutdown(ctx, true, p.TimeoutSeconds)
+	if err != nil {
+		return err
+	}
+
+	// Wait for shutdown
+	log.Printf("Waiting for %s to shutdown", ctr.Name)
+	if err = task.WaitFor(ctx, p.TimeoutSeconds); err != nil {
+		return
+	}
+
+	// Delete container
+	if task, err = ctr.Delete(ctx); err != nil {
+		return
+	}
+
+	// Wait for deletion
+	log.Printf("Waiting for %s to be deleted", ctr.Name)
+	if err = task.WaitFor(ctx, p.TimeoutSeconds); err != nil {
+		return
+	}
+
+	log.Printf("%s deleted!\n", ctr.Name)
+	return
+}
+
+func (p *ProxmoxManager) JoinIpToK8s(ip netip.Addr) (err error) {
+	joinCmd := k3sup.MakeJoin()
+
+	joinCmd.Flags().Set("ssh-key", p.SshKeyFile)
+	joinCmd.Flags().Set("server-user", p.ServerUser)
+	joinCmd.Flags().Set("server-host", p.ServerHost)
+	joinCmd.Flags().Set("user", p.User)
+	joinCmd.Flags().Set("host", ip.String())
+
+	log.Printf("Joining %v to %s\n", ip, p.ServerHost)
+	if err = joinCmd.Execute(); err == nil {
+		log.Println("Joined!")
+	}
+	return
+}
 
 type ProxmoxCloudProvider struct {
 	config *ProxmoxManager
@@ -59,3 +255,8 @@ func newProxmoxCloudProvider(config *ProxmoxManager) *ProxmoxCloudProvider {
 }
 
 // cloudProvider.CloudProvider interface implementation on ProxmoxCloudProvider
+
+// Name returns name of the cloud provider.
+func (d *ProxmoxCloudProvider) Name() string {
+	return cloudprovider.ProxmoxProviderName
+}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -277,19 +277,22 @@ func (n *NodeGroupManager) DeleteCt(ctx context.Context, ctrOffset int) (err err
 	}
 
 	// Shutdown container
-	task, err := ctr.Shutdown(ctx, true, n.TimeoutSeconds)
-	if err != nil {
-		return err
-	}
+	if ctr.Status == "running" {
+		task, err := ctr.Shutdown(ctx, true, n.TimeoutSeconds)
+		if err != nil {
+			return err
+		}
 
-	// Wait for shutdown
-	log.Printf("Waiting for %s to shutdown", ctr.Name)
-	if err = task.WaitFor(ctx, n.TimeoutSeconds); err != nil {
-		return
+		// Wait for shutdown
+		log.Printf("Waiting for %s to shutdown", ctr.Name)
+		if err = task.WaitFor(ctx, n.TimeoutSeconds); err != nil {
+			return err
+		}
 	}
 
 	// Delete container
-	if task, err = ctr.Delete(ctx); err != nil {
+	task, err := ctr.Delete(ctx)
+	if err != nil {
 		return
 	}
 

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -125,7 +125,9 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 		NodeGroupManagers: nodeGroupManagers,
 	}
 
-	proxmoxManager.getInitialDetails(context.Background())
+	if err = proxmoxManager.getInitialDetails(context.Background()); err != nil {
+		return
+	}
 
 	return proxmoxManager, nil
 }
@@ -170,6 +172,13 @@ func (p *ProxmoxManager) getInitialDetails(ctx context.Context) (err error) {
 			return
 		}
 		ngm.targetSize = ngm.currentSize
+
+		// At least one node
+		if ngm.currentSize == 0 {
+			if err := ngm.IncreaseSize(1); err != nil {
+				return err
+			}
+		}
 	}
 
 	return

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -1,0 +1,61 @@
+package proxmox
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/luthermonson/go-proxmox"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+// Configuration of the Proxmox Cloud Provider
+type Config struct {
+	InsecureSkipVerify   bool
+	ApiUser              string
+	ApiToken             string
+	TargetPool           string
+	ReferenceContainerId int
+}
+
+type ProxmoxManager struct {
+	Client         *proxmox.Client
+	TargetPool     string
+	RefCtrId       int
+	TimeoutSeconds int
+
+	node   *proxmox.Node
+	refCtr *proxmox.Container
+}
+
+func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager, err error) {
+	data, err := io.ReadAll(configFileReader)
+	if err != nil {
+		return
+	}
+
+	config := Config{}
+	if err = json.Unmarshal(data, config); err != nil {
+		return
+	}
+
+	return &ProxmoxManager{
+		Client:         nil,
+		TargetPool:     config.TargetPool,
+		RefCtrId:       config.ReferenceContainerId,
+		TimeoutSeconds: con,
+	}
+}
+
+// TODO: Implement proxmox interations on proxmoxManager
+
+type ProxmoxCloudProvider struct {
+	config *ProxmoxManager
+}
+
+func newProxmoxCloudProvider(config *ProxmoxManager) *ProxmoxCloudProvider {
+	return &ProxmoxCloudProvider{
+		config: config,
+	}
+}
+
+// cloudProvider.CloudProvider interface implementation on ProxmoxCloudProvider

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -365,7 +365,7 @@ func (p *ProxmoxManager) getDetailsFromNode(node *apiv1.Node) (n *NodeGroupManag
 	}
 
 	// Not managed by us
-	if targetPool == "" && refCtrId == 0 && offset == 0 {
+	if targetPool == "" || refCtrId == 0 || offset == 0 {
 		return
 	}
 

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -22,6 +22,8 @@ type NodeConfig struct {
 	RefCtrId         int
 	TargetPool       string
 	WorkerNamePrefix string
+	MinSize          int
+	MaxSize          int
 }
 
 type K3sConfig struct {
@@ -44,7 +46,7 @@ type Config struct {
 
 type NodeGroupManager struct {
 	Client         *pm.Client
-	NodeConfig     NodeConfig
+	NodeConfig     *NodeConfig
 	K3sConfig      *K3sConfig
 	TimeoutSeconds int
 
@@ -86,7 +88,7 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 	for _, nc := range config.NodeConfigs {
 		nodeGroupManagers = append(nodeGroupManagers, NodeGroupManager{
 			Client:         client,
-			NodeConfig:     nc,
+			NodeConfig:     &nc,
 			K3sConfig:      &config.K3sConfig,
 			TimeoutSeconds: config.TimeoutSeconds,
 		})

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	k3sup "github.com/alexellis/k3sup/cmd"
-	"github.com/luthermonson/go-proxmox"
 	pm "github.com/luthermonson/go-proxmox"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -76,7 +75,7 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 	}
 
 	config := Config{}
-	if err = json.Unmarshal(data, config); err != nil {
+	if err = json.Unmarshal(data, &config); err != nil {
 		return
 	}
 
@@ -122,7 +121,7 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 func (p *ProxmoxManager) getInitialDetails(ctx context.Context) (err error) {
 	// Get first node name
 	log.Println("Getting first node")
-	var nodeStatuses proxmox.NodeStatuses
+	var nodeStatuses pm.NodeStatuses
 	nodeStatuses, err = p.Client.Nodes(ctx)
 	if err != nil {
 		return
@@ -166,7 +165,7 @@ func (n *NodeGroupManager) cloneToNewCt(ctx context.Context, newCtrOffset int) (
 	// Clone reference container. Return value is 0 when providing NewID
 	newId := n.NodeConfig.RefCtrId + newCtrOffset
 	log.Printf("Cloning reference container %s to new container %d\n", n.refCtr.Name, newId)
-	_, task, err := n.refCtr.Clone(ctx, &proxmox.ContainerCloneOptions{
+	_, task, err := n.refCtr.Clone(ctx, &pm.ContainerCloneOptions{
 		NewID:    newId,
 		Hostname: fmt.Sprintf("%s-%d", n.NodeConfig.WorkerNamePrefix, newCtrOffset),
 		Pool:     n.NodeConfig.TargetPool,

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -54,7 +54,7 @@ type NodeGroupManager struct {
 
 type ProxmoxManager struct {
 	Client            *pm.Client
-	NodeGroupManagers []*NodeGroupManager
+	NodeGroupManagers []NodeGroupManager
 }
 
 func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager, err error) {
@@ -81,10 +81,10 @@ func newProxmoxManager(configFileReader io.ReadCloser) (proxmox *ProxmoxManager,
 		pm.WithAPIToken(config.ApiUser, config.ApiToken),
 	)
 
-	nodeGroupManagers := make([]*NodeGroupManager, len(config.NodeConfigs))
+	nodeGroupManagers := make([]NodeGroupManager, len(config.NodeConfigs))
 
 	for _, nc := range config.NodeConfigs {
-		nodeGroupManagers = append(nodeGroupManagers, &NodeGroupManager{
+		nodeGroupManagers = append(nodeGroupManagers, NodeGroupManager{
 			Client:         client,
 			NodeConfig:     nc,
 			K3sConfig:      &config.K3sConfig,

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_interaction.go
@@ -263,18 +263,13 @@ func (n *NodeGroupManager) JoinIpToK8s(ip netip.Addr) (err error) {
 }
 
 type ProxmoxCloudProvider struct {
-	config *ProxmoxManager
+	manager         *ProxmoxManager
+	resourceLimiter *cloudprovider.ResourceLimiter
 }
 
-func newProxmoxCloudProvider(config *ProxmoxManager) *ProxmoxCloudProvider {
+func newProxmoxCloudProvider(manager *ProxmoxManager, rl *cloudprovider.ResourceLimiter) *ProxmoxCloudProvider {
 	return &ProxmoxCloudProvider{
-		config: config,
+		manager:         manager,
+		resourceLimiter: rl,
 	}
-}
-
-// cloudProvider.CloudProvider interface implementation on ProxmoxCloudProvider
-
-// Name returns name of the cloud provider.
-func (p *ProxmoxCloudProvider) Name() string {
-	return cloudprovider.ProxmoxProviderName
 }

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -107,7 +107,7 @@ func (n *NodeGroupManager) DeleteNodes(nodes []*apiv1.Node) error {
 	for _, node := range nodes {
 		refId, ok1 := node.Labels[RefIdLabel]
 		nodeOffsetStr, ok2 := node.Labels[OffsetLabel]
-		if !(ok1 && ok2 && refId == string(n.NodeConfig.RefCtrId)) {
+		if !(ok1 && ok2 && refId == fmt.Sprint(n.NodeConfig.RefCtrId)) {
 			return fmt.Errorf("node %s does not belong to proxmox pool %s", node.Name, n.NodeConfig.TargetPool)
 		}
 		nodeOffset, err := strconv.Atoi(nodeOffsetStr)
@@ -115,7 +115,7 @@ func (n *NodeGroupManager) DeleteNodes(nodes []*apiv1.Node) error {
 			return err
 		}
 		if nodeOffset <= 0 {
-			fmt.Errorf("node id out of range. node name: %s", node.Name)
+			return fmt.Errorf("node id out of range. node name: %s", node.Name)
 		}
 		if err := n.DeleteCt(ctx, nodeOffset); err != nil {
 			return err

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -20,7 +20,7 @@ func (n *NodeGroupManager) GetPoolNodes(ctx context.Context) ([]*pm.ClusterResou
 		return nil, err
 	}
 
-	nodes := make([]*pm.ClusterResource, len(pool.Members))
+	nodes := make([]*pm.ClusterResource, 0, len(pool.Members))
 	for _, ctr := range pool.Members {
 		if strings.HasPrefix(ctr.Name, fmt.Sprintf("%s-", n.NodeConfig.WorkerNamePrefix)) {
 			nodes = append(nodes, &ctr)

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -1,0 +1,91 @@
+package proxmox
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// MaxSize returns maximum size of the node group.
+func (n *NodeGroupManager) MaxSize() int {}
+
+// MinSize returns minimum size of the node group.
+func (n *NodeGroupManager) MinSize() int {}
+
+// TargetSize returns the current target size of the node group. It is possible that the
+// number of nodes in Kubernetes is different at the moment but should be equal
+// to Size() once everything stabilizes (new nodes finish startup and registration or
+// removed nodes are deleted completely). Implementation required.
+func (n *NodeGroupManager) TargetSize() (int, error) {}
+
+// IncreaseSize increases the size of the node group. To delete a node you need
+// to explicitly name it and use DeleteNode. This function should wait until
+// node group size is updated. Implementation required.
+func (n *NodeGroupManager) IncreaseSize(delta int) error {}
+
+// AtomicIncreaseSize tries to increase the size of the node group atomically.
+//   - If the method returns nil, it guarantees that delta instances will be added to the node group
+//     within its MaxNodeProvisionTime. The function should wait until node group size is updated.
+//     The cloud provider is responsible for tracking and ensuring successful scale up asynchronously.
+//   - If the method returns an error, it guarantees that no new instances will be added to the node group
+//     as a result of this call. The cloud provider is responsible for ensuring that before returning from the method.
+//
+// Implementation is optional. If implemented, CA will take advantage of the method while scaling up
+// GenericScaleUp ProvisioningClass, guaranteeing that all instances required for such a ProvisioningRequest
+// are provisioned atomically.
+func (n *NodeGroupManager) AtomicIncreaseSize(delta int) error {}
+
+// DeleteNodes deletes nodes from this node group. Error is returned either on
+// failure or if the given node doesn't belong to this node group. This function
+// should wait until node group size is updated. Implementation required.
+func (n *NodeGroupManager) DeleteNodes([]*apiv1.Node) error {}
+
+// DecreaseTargetSize decreases the target size of the node group. This function
+// doesn't permit to delete any existing node and can be used only to reduce the
+// request for new nodes that have not been yet fulfilled. Delta should be negative.
+// It is assumed that cloud provider will not delete the existing nodes when there
+// is an option to just decrease the target. Implementation required.
+func (n *NodeGroupManager) DecreaseTargetSize(delta int) error {}
+
+// Id returns an unique identifier of the node group.
+func (n *NodeGroupManager) Id() string {}
+
+// Debug returns a string containing all information regarding this node group.
+func (n *NodeGroupManager) Debug() string {}
+
+// Nodes returns a list of all nodes that belong to this node group.
+// It is required that Instance objects returned by this method have Id field set.
+// Other fields are optional.
+// This list should include also instances that might have not become a kubernetes node yet.
+func (n *NodeGroupManager) Nodes() ([]cloudprovider.Instance, error) {}
+
+// TemplateNodeInfo returns a schedulerframework.NodeInfo structure of an empty
+// (as if just started) node. This will be used in scale-up simulations to
+// predict what would a new node look like if a node group was expanded. The returned
+// NodeInfo is expected to have a fully populated Node object, with all of the labels,
+// capacity and allocatable information as well as all pods that are started on
+// the node by default, using manifest (most likely only kube-proxy). Implementation optional.
+func (n *NodeGroupManager) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {}
+
+// Exist checks if the node group really exists on the cloud provider side. Allows to tell the
+// theoretical node group from the real one. Implementation required.
+func (n *NodeGroupManager) Exist() bool {}
+
+// Create creates the node group on the cloud provider side. Implementation optional.
+func (n *NodeGroupManager) Create() (cloudprovider.NodeGroup, error) {}
+
+// Delete deletes the node group on the cloud provider side.
+// This will be executed only for autoprovisioned node groups, once their size drops to 0.
+// Implementation optional.
+func (n *NodeGroupManager) Delete() error {}
+
+// Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
+// was created by CA and can be deleted when scaled to 0.
+func (n *NodeGroupManager) Autoprovisioned() bool {}
+
+// GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
+// NodeGroup. Returning a nil will result in using default options.
+// Implementation optional. Callers MUST handle `cloudprovider.ErrNotImplemented`.
+func (n *NodeGroupManager) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -3,29 +3,39 @@ package proxmox
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
+	pm "github.com/luthermonson/go-proxmox"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-func (n *NodeGroupManager) FillCurrentSize(ctx context.Context) error {
+func (n *NodeGroupManager) GetPoolNodes(ctx context.Context) ([]*pm.ClusterResource, error) {
 	// List existing LXC containers
 	pool, err := n.Client.Pool(ctx, n.NodeConfig.TargetPool, "lxc")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Count number of existing nodes
-	n.currentSize = 0
+	nodes := make([]*pm.ClusterResource, len(pool.Members))
 	for _, ctr := range pool.Members {
-		if strings.HasPrefix(ctr.Name, fmt.Sprintf("%s-", n.NodeConfig.WorkerNamePrefix)) && ctr.Status == "running" {
-			n.currentSize += 1
+		if strings.HasPrefix(ctr.Name, fmt.Sprintf("%s-", n.NodeConfig.WorkerNamePrefix)) {
+			nodes = append(nodes, &ctr)
 		}
 	}
 
+	return nodes, nil
+}
+
+func (n *NodeGroupManager) FillCurrentSize(ctx context.Context) error {
+	if resources, err := n.GetPoolNodes(ctx); err != nil {
+		return err
+	} else {
+		n.currentSize = len(resources)
+	}
 	return nil
 }
 
@@ -85,31 +95,71 @@ func (n *NodeGroupManager) IncreaseSize(delta int) error {
 // Implementation is optional. If implemented, CA will take advantage of the method while scaling up
 // GenericScaleUp ProvisioningClass, guaranteeing that all instances required for such a ProvisioningRequest
 // are provisioned atomically.
-func (n *NodeGroupManager) AtomicIncreaseSize(delta int) error {}
+func (n *NodeGroupManager) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *NodeGroupManager) DeleteNodes([]*apiv1.Node) error {}
+func (n *NodeGroupManager) DeleteNodes(nodes []*apiv1.Node) error {
+	prefix := fmt.Sprintf("%s-", n.NodeConfig.WorkerNamePrefix)
+	ctx := context.Background()
+	for _, node := range nodes {
+		if !strings.HasPrefix(node.Name, prefix) {
+			return fmt.Errorf("node %s does not belong to proxmox pool %s", node.Name, n.NodeConfig.TargetPool)
+		}
+		nodeToDelete, err := strconv.Atoi(strings.TrimPrefix(node.Name, prefix))
+		if err != nil {
+			return err
+		}
+		nodeOffset := nodeToDelete - n.NodeConfig.RefCtrId
+		if nodeOffset <= 0 {
+			fmt.Errorf("node id out of range. node name: %s", node.Name)
+		}
+		if err := n.DeleteCt(ctx, nodeOffset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroupManager) DecreaseTargetSize(delta int) error {}
+func (n *NodeGroupManager) DecreaseTargetSize(delta int) error {
+	// TODO: ???
+	return nil
+}
 
 // Id returns an unique identifier of the node group.
-func (n *NodeGroupManager) Id() string {}
+func (n *NodeGroupManager) Id() string {
+	return n.NodeConfig.TargetPool
+}
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroupManager) Debug() string {}
+func (n *NodeGroupManager) Debug() string {
+	return fmt.Sprintf("%+v\n", n)
+}
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (n *NodeGroupManager) Nodes() ([]cloudprovider.Instance, error) {}
+func (n *NodeGroupManager) Nodes() (instance []cloudprovider.Instance, err error) {
+	nodes, err := n.GetPoolNodes(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes {
+		instance = append(instance, cloudprovider.Instance{
+			Id: node.Name,
+		})
+	}
+	return
+}
 
 // TemplateNodeInfo returns a schedulerframework.NodeInfo structure of an empty
 // (as if just started) node. This will be used in scale-up simulations to
@@ -117,26 +167,41 @@ func (n *NodeGroupManager) Nodes() ([]cloudprovider.Instance, error) {}
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (n *NodeGroupManager) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {}
+func (n *NodeGroupManager) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (n *NodeGroupManager) Exist() bool {}
+func (n *NodeGroupManager) Exist() bool {
+	return true
+}
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (n *NodeGroupManager) Create() (cloudprovider.NodeGroup, error) {}
+func (n *NodeGroupManager) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroupManager) Delete() error {}
+func (n *NodeGroupManager) Delete() error {
+	return cloudprovider.ErrNotImplemented
+}
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroupManager) Autoprovisioned() bool {}
+func (n *NodeGroupManager) Autoprovisioned() bool {
+	return false
+}
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional. Callers MUST handle `cloudprovider.ErrNotImplemented`.
 func (n *NodeGroupManager) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	if n.NodeConfig.AutoScalingOptions == (config.NodeGroupAutoscalingOptions{}) {
+		return nil, nil
+	} else {
+		return &n.NodeConfig.AutoScalingOptions, nil
+	}
 }

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -3,7 +3,6 @@ package proxmox
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	pm "github.com/luthermonson/go-proxmox"
@@ -106,17 +105,9 @@ func (n *NodeGroupManager) AtomicIncreaseSize(delta int) error {
 func (n *NodeGroupManager) DeleteNodes(nodes []*apiv1.Node) error {
 	ctx := context.Background()
 	for _, node := range nodes {
-		refId, ok1 := node.Labels[RefIdLabel]
-		nodeOffsetStr, ok2 := node.Labels[OffsetLabel]
-		if !(ok1 && ok2 && refId == fmt.Sprint(n.NodeConfig.RefCtrId)) {
-			return fmt.Errorf("node %s does not belong to proxmox pool %s", node.Name, n.NodeConfig.TargetPool)
-		}
-		nodeOffset, err := strconv.Atoi(nodeOffsetStr)
+		nodeOffset, err := n.OwnedNodeOffset(node)
 		if err != nil {
 			return err
-		}
-		if nodeOffset <= 0 {
-			return fmt.Errorf("node id out of range. node name: %s", node.Name)
 		}
 		if err := n.DeleteCt(ctx, nodeOffset); err != nil {
 			return err
@@ -169,6 +160,7 @@ func (n *NodeGroupManager) Nodes() (instance []cloudprovider.Instance, err error
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
 func (n *NodeGroupManager) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
+	// TODO: implement this
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -103,17 +103,17 @@ func (n *NodeGroupManager) AtomicIncreaseSize(delta int) error {
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
 func (n *NodeGroupManager) DeleteNodes(nodes []*apiv1.Node) error {
-	prefix := fmt.Sprintf("%s-", n.NodeConfig.WorkerNamePrefix)
 	ctx := context.Background()
 	for _, node := range nodes {
-		if !strings.HasPrefix(node.Name, prefix) {
+		refId, ok1 := node.Labels[RefIdLabel]
+		nodeOffsetStr, ok2 := node.Labels[OffsetLabel]
+		if !(ok1 && ok2 && refId == string(n.NodeConfig.RefCtrId)) {
 			return fmt.Errorf("node %s does not belong to proxmox pool %s", node.Name, n.NodeConfig.TargetPool)
 		}
-		nodeToDelete, err := strconv.Atoi(strings.TrimPrefix(node.Name, prefix))
+		nodeOffset, err := strconv.Atoi(nodeOffsetStr)
 		if err != nil {
 			return err
 		}
-		nodeOffset := nodeToDelete - n.NodeConfig.RefCtrId
 		if nodeOffset <= 0 {
 			fmt.Errorf("node id out of range. node name: %s", node.Name)
 		}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -77,6 +77,7 @@ func (n *NodeGroupManager) IncreaseSize(delta int) error {
 	ctx := context.Background()
 	for i := n.currentSize + 1; i <= targetSize; i++ {
 		if err := n.CreateK3sWorker(ctx, i); err != nil {
+			n.DeleteCt(ctx, i)
 			n.FillCurrentSize(ctx)
 			return err
 		}

--- a/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
+++ b/cluster-autoscaler/cloudprovider/proxmox/proxmox_node_group_impl.go
@@ -199,9 +199,8 @@ func (n *NodeGroupManager) Autoprovisioned() bool {
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional. Callers MUST handle `cloudprovider.ErrNotImplemented`.
 func (n *NodeGroupManager) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	if n.NodeConfig.AutoScalingOptions == (config.NodeGroupAutoscalingOptions{}) {
-		return nil, nil
-	} else {
-		return &n.NodeConfig.AutoScalingOptions, nil
+	if n.NodeConfig.AutoScalingOptions != nil {
+		return n.NodeConfig.AutoScalingOptions, nil
 	}
+	return nil, nil
 }

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/jmattheis/goverter v1.4.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/json-iterator/go v1.1.12
+	github.com/luthermonson/go-proxmox v0.0.0-beta6
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
@@ -102,6 +103,7 @@ require (
 	github.com/dave/jennifer v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
+	github.com/diskfs/go-diskfs v1.2.0 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
@@ -136,10 +138,12 @@ require (
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181029123624-5de817a9aa20 // indirect
+	github.com/jinzhu/copier v0.3.4 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libopenstorage/openstorage v1.0.0 // indirect
+	github.com/magefile/mage v1.14.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/skewer v0.0.14
+	github.com/alexellis/k3sup v0.0.0-20240515101735-23a7535dac66
 	github.com/aws/aws-sdk-go v1.44.241
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/digitalocean/godo v1.27.0
@@ -28,7 +29,7 @@ require (
 	github.com/jmattheis/goverter v1.4.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/json-iterator/go v1.1.12
-	github.com/luthermonson/go-proxmox v0.0.0-beta6
+	github.com/luthermonson/go-proxmox v0.0.0-beta6.0.20240404232304-fe3dbec855e9
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
@@ -152,6 +153,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mrunalp/fileutils v0.5.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -369,8 +369,8 @@ github.com/libopenstorage/openstorage v1.0.0 h1:GLPam7/0mpdP8ZZtKjbfcXJBTIA/T1O6
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
-github.com/luthermonson/go-proxmox v0.0.0-beta6 h1:FP++LrHu237kdaH/gH3qPjQEkplOFxIOFvNnVcQ6ypo=
-github.com/luthermonson/go-proxmox v0.0.0-beta6/go.mod h1:wkD6045y9lKBCP0sJGjNqmlBCo0vwRwnfhmsrPBTu34=
+github.com/luthermonson/go-proxmox v0.0.0-beta6.0.20240404232304-fe3dbec855e9 h1:djRoPoXbyBX62prwrE+uUhzJIkdl5r691IyE2ZF+tCM=
+github.com/luthermonson/go-proxmox v0.0.0-beta6.0.20240404232304-fe3dbec855e9/go.mod h1:wkD6045y9lKBCP0sJGjNqmlBCo0vwRwnfhmsrPBTu34=
 github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
 github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -393,6 +393,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb h1:e+l77LJOEqXTIQihQJVkA6ZxPOUmfPM5e4H7rcpgtSk=
 github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
+github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.1 h1:F+S7ZlNKnrwHfSwdlgNSkKo67ReVf8o9fel6C3dkm/Q=
 github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -1,3 +1,4 @@
+4d63.com/gochecknoinits v0.0.0-20200108094044-eb73b47b9fc4/go.mod h1:4o1i5aXtIF5tJFt3UD1knCVmWOXg7fLYdHVu6jeNcnM=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -111,6 +112,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
+github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -172,6 +175,8 @@ github.com/digitalocean/godo v1.27.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjR
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/diskfs/go-diskfs v1.2.0 h1:Ow4xorEDw1VNYKbC+SA/qQNwi5gWIwdKUxmUcLFST24=
+github.com/diskfs/go-diskfs v1.2.0/go.mod h1:ZTeTbzixuyfnZW5y5qKMtjV2o+GLLHo1KfMhotJI4Rk=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
@@ -297,6 +302,7 @@ github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -325,6 +331,9 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.1-0.20181029123624-5de817a9aa20 h1:dAOsPLhnBzIyxu0VvmnKjlNcIlgMK+erD6VRHDtweMI=
 github.com/jessevdk/go-flags v1.4.1-0.20181029123624-5de817a9aa20/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jgautheron/goconst v0.0.0-20170703170152-9740945f5dcb/go.mod h1:82TxjOpWQiPmywlbIaB2ZkqJoSYJdLGPgAJDvM3PbKc=
+github.com/jinzhu/copier v0.3.4 h1:mfU6jI9PtCeUjkjQ322dlff9ELjGDu975C2p/nrubVI=
+github.com/jinzhu/copier v0.3.4/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmattheis/goverter v1.4.0 h1:SrboBYMpGkj1XSgFhWwqzdP024zIa1+58YzUm+0jcBE=
 github.com/jmattheis/goverter v1.4.0/go.mod h1:iVIl/4qItWjWj2g3vjouGoYensJbRqDHpzlEVMHHFeY=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -360,6 +369,10 @@ github.com/libopenstorage/openstorage v1.0.0 h1:GLPam7/0mpdP8ZZtKjbfcXJBTIA/T1O6
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/luthermonson/go-proxmox v0.0.0-beta6 h1:FP++LrHu237kdaH/gH3qPjQEkplOFxIOFvNnVcQ6ypo=
+github.com/luthermonson/go-proxmox v0.0.0-beta6/go.mod h1:wkD6045y9lKBCP0sJGjNqmlBCo0vwRwnfhmsrPBTu34=
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
@@ -484,7 +497,9 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vburenin/ifacemaker v1.2.1 h1:3Vq8B/bfBgjWTkv+jDg4dVL1KHt3k1K4lO7XRxYA2sk=
 github.com/vburenin/ifacemaker v1.2.1/go.mod h1:5WqrzX2aD7/hi+okBjcaEQJMg4lDGrpuEX3B8L4Wgrs=
@@ -618,6 +633,7 @@ golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -631,6 +647,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds support for Proxmox as a cluster autoscaler target.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
~Fixes #~

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: https://github.com/adyanth/autoscaler/blob/fa4cd972cc98c7a7680c6b5a97c1197795722697/cluster-autoscaler/cloudprovider/proxmox/README.md
```
